### PR TITLE
Fixed errors only at /signers/* folder

### DIFF
--- a/packages/core/services/signers/BitcoinLedgerDevice.js
+++ b/packages/core/services/signers/BitcoinLedgerDevice.js
@@ -5,17 +5,16 @@
 
 import EventEmitter from 'events'
 import bitcoin from 'bitcoinjs-lib'
-import coinselect from 'coinselect'
 import TransportU2F from '@ledgerhq/hw-transport-u2f'
 import AppBTC from '@ledgerhq/hw-app-btc'
 import axios from 'axios'
 
 export const API = axios.create({
-  baseURL: 'https://test-insight.bitpay.com/api/'
+  baseURL: 'https://test-insight.bitpay.com/api/',
 })
 
 export default class BitcoinLedgerDevice extends EventEmitter {
-  constructor ({network}) {
+  constructor ({ network }) {
     super()
     this.network = network
     Object.freeze(this)
@@ -24,9 +23,9 @@ export default class BitcoinLedgerDevice extends EventEmitter {
   // this method is a part of base interface
   async getAddress (path) {
     const transport = await TransportU2F.create()
-    const app = new AppBtc(transport)
+    const app = new AppBTC(transport)
     const result = await app.getWalletPublicKey(path)
-    return result.bitcoinAddress	  
+    return result.bitcoinAddress
   }
 
   async serializeTransactionOutputs (...args) {
@@ -47,30 +46,32 @@ export default class BitcoinLedgerDevice extends EventEmitter {
     const app = new AppBTC(transport)
     return app.createPaymentTransactionNew(...args)
   }
-	
-  async signTransaction (rawTx, path) { // tx object
-    const txb = new bitcoin.TransactionBuilder.fromTransaction (
-        bitcoin.Transaction.fromHex (rawTx), this.network)
 
-    let inputs = []
+  async signTransaction (rawTx, path) {
+    // tx object
+    const txb = new bitcoin.TransactionBuilder.fromTransaction(bitcoin.Transaction.fromHex(rawTx), this.network)
+
+    const inputs = []
 
     await txb.buildIncomplete().ins.forEach(async (input) => {
-      console.log(Buffer.from(input.hash).reverse().toString('hex'))
-      const { data } = await API.get(`rawtx/${Buffer.from(input.hash).reverse().toString('hex')}`) 
-      console.log(data)
+      // console.log(
+      //   Buffer.from(input.hash)
+      //     .reverse()
+      //     .toString('hex')
+      // )
+      const { data } = await API.get(
+        `rawtx/${Buffer.from(input.hash)
+          .reverse()
+          .toString('hex')}`
+      )
+      // console.log(data)
       inputs.push([await this.splitTransaction(data.rawtx), input.index])
     })
-    console.log(inputs)
+    // console.log(inputs)
     const bufferedInput = await this.splitTransaction(rawTx)
     const outputScript = await this.serializeTransactionOutputs(bufferedInput)
-    const outputScriptHex = await outputScript.toString("hex")
-    const result = await this
-      .createPaymentTransactionNew(
-      inputs,
-      [path],
-      path,
-      outputScriptHex
-      )
+    const outputScriptHex = await outputScript.toString('hex')
+    const result = await this.createPaymentTransactionNew(inputs, [path], path, outputScriptHex)
+    return result
   }
-
 }

--- a/packages/core/services/signers/BitcoinLedgerDeviceMock.js
+++ b/packages/core/services/signers/BitcoinLedgerDeviceMock.js
@@ -4,13 +4,10 @@
  */
 
 import EventEmitter from 'events'
-import bip39 from 'bip39'
 import bitcoin from 'bitcoinjs-lib'
-import coinselect from 'coinselect'
-import axios from 'axios'
 
-export default class BitcoinMemoryDevice extends EventEmitter {
-  constructor ({seed, network}) {
+export default class BitcoinLedgerDeviceMock extends EventEmitter {
+  constructor ({ seed, network }) {
     super()
     this.seed = seed
     this.network = network
@@ -18,7 +15,7 @@ export default class BitcoinMemoryDevice extends EventEmitter {
   }
 
   privateKey (path) {
-    return this._getDerivedWallet(path).privateKey 
+    return this._getDerivedWallet(path).privateKey
   }
 
   // this method is a part of base interface
@@ -26,25 +23,25 @@ export default class BitcoinMemoryDevice extends EventEmitter {
     return this._getDerivedWallet(path).getAddress()
   }
 
-  signTransaction (rawTx, path) { // tx object
-    const txb = new bitcoin.TransactionBuilder.fromTransaction (
-      bitcoin.Transaction.fromHex (txhex), this.network)
+  signTransaction (rawTx, path) {
+    // tx object
+    const txb = new bitcoin.TransactionBuilder
+      .fromTransaction(bitcoin.Transaction.fromHex(txhex), this.network)
     for (let i = 0; i < txb.inputs.length; i++) {
-      txb.sign(i, _getDerivedWallet(path).keyPair)
+      txb.sign(i, this._getDerivedWallet(path).keyPair)
     }
-    const tx = txb.build ();
-    const txhex = tx.toHex ();
+    const tx = txb.build()
+    const txhex = tx.toHex()
     return txhex
   }
 
-  _getDerivedWallet(derivedPath) {
-    if(this.seed) {
+  _getDerivedWallet (derivedPath) {
+    if (this.seed) {
       const wallet = bitcoin.HDNode
         .fromSeedBuffer(Buffer.from(this.seed.substring(2), 'hex'), bitcoin.networks.testnet)
         .derivePath(derivedPath)
-      console.log(wallet)
+      // console.log(wallet)
       return wallet
     }
   }
-
 }

--- a/packages/core/services/signers/BitcoinMemoryDevice.js
+++ b/packages/core/services/signers/BitcoinMemoryDevice.js
@@ -7,7 +7,7 @@ import EventEmitter from 'events'
 import bitcore from 'bitcore-lib'
 
 export default class BitcoinMemoryDevice extends EventEmitter {
-  constructor ({seed, network}) {
+  constructor ({ seed, network }) {
     super()
     this.seed = seed
     this.network = network
@@ -15,7 +15,7 @@ export default class BitcoinMemoryDevice extends EventEmitter {
   }
 
   privateKey (path) {
-    return this._getDerivedWallet(path).privateKey 
+    return this._getDerivedWallet(path).privateKey
   }
 
   // this method is a part of base interface
@@ -24,85 +24,83 @@ export default class BitcoinMemoryDevice extends EventEmitter {
   }
 
   _prepareSignedTransaction (unsignedTx) {
-      const txobj = {} 
-      txobj.version    = unsignedTx.version
-      txobj.lock_time  = unsignedTx.lock_time
-      txobj.ins  = []
-      for (let i=0; i < unsignedTx.ins.length; i++) {
-          txobj.ins.push({
-              s: bitcore.util.EMPTY_BUFFER,
-              q: unsignedTx.ins[i].q,
-              o: unsignedTx.ins[i].o
-          });
-      }  
-      txobj.outs = unsignedTx.outs
-      return new bitcore.Transaction(txobj)
+    const txobj = {}
+    txobj.version = unsignedTx.version
+    txobj.lock_time = unsignedTx.lock_time
+    txobj.ins = []
+    for (let i = 0; i < unsignedTx.ins.length; i++) {
+      txobj.ins.push({
+        s: bitcore.util.EMPTY_BUFFER,
+        q: unsignedTx.ins[i].q,
+        o: unsignedTx.ins[i].o,
+      })
+    }
+    txobj.outs = unsignedTx.outs
+    return new bitcore.Transaction(txobj)
   }
 
   signTransaction (unsignedHex, path) {
+    // function used to each for each type
+    const fnToSign = {}
+    /* eslint-disable no-underscore-dangle */
+    fnToSign[bitcore.Script.TX_PUBKEYHASH] = bitcore.TransactionBuilder.prototype._signPubKeyHash
+    fnToSign[bitcore.Script.TX_PUBKEY] = bitcore.TransactionBuilder.prototype._signPubKey
+    fnToSign[bitcore.Script.TX_MULTISIG] = bitcore.TransactionBuilder.prototype._signMultiSig
+    fnToSign[bitcore.Script.TX_SCRIPTHASH] = bitcore.TransactionBuilder.prototype._signScriptHash
+    /* eslint-enable no-underscore-dangle */
 
-      // function used to each for each type
-      const fnToSign = {}
-      fnToSign[bitcore.Script.TX_PUBKEYHASH] = bitcore.TransactionBuilder.prototype._signPubKeyHash
-      fnToSign[bitcore.Script.TX_PUBKEY]     = bitcore.TransactionBuilder.prototype._signPubKey
-      fnToSign[bitcore.Script.TX_MULTISIG]   = bitcore.TransactionBuilder.prototype._signMultiSig
-      fnToSign[bitcore.Script.TX_SCRIPTHASH] = bitcore.TransactionBuilder.prototype._signScriptHash
+    // build key map
+    const address = this.getAddress(path)
+    const wkMap = {}
+    wkMap[address] = new bitcore.WalletKey({ network: this.network, privKey: this.privateKey(path) })
 
-      // build key map
-      const address = this.getAddress(path)
-      let wkMap = {}
-      wkMap[address] = new bitcore.WalletKey({network:this.network, privKey:this.privateKey(path)}) 
+    // unserialize raw transaction
+    const raw = new bitcore.buffertools.Buffer(unsignedHex, 'hex')
+    const unsignedTx = new bitcore.Transaction()
+    unsignedTx.parse(raw)
 
-      // unserialize raw transaction
-      const raw = new bitcore.buffertools.Buffer(unsignedHex, 'hex')
-      const unsignedTx = new bitcore.Transaction()
-      unsignedTx.parse(raw)
+    // prepare  signed transaction
+    const signedTx = new bitcore.TransactionBuilder()
+    signedTx.tx = this._prepareSignedTransaction(unsignedTx)
 
-      // prepare  signed transaction
-      const signedTx = new bitcore.TransactionBuilder()
-      signedTx.tx = this._prepareSignedTransaction(unsignedTx)
-
-      for (let i=0; i < unsignedTx.ins.length; i++) {
-          
-          // init parameters
-          const txin = unsignedTx.ins[i]
-          const scriptPubKey = new bitcore.Script(txin.s)
-          const input = {
-              address: address,
-              scriptPubKey: scriptPubKey,
-              scriptType: scriptPubKey.classify(),
-              i: i
-          }
-
-          // generating hash for signature
-          const txSigHash = unsignedTx.hashForSignature(scriptPubKey, i, bitcore.Transaction.SIGHASH_ALL)
-          
-          // sign hash
-          const ret = fnToSign[input.scriptType].call(signedTx, wkMap, input, txSigHash)
-          
-          // inject signed script in transaction object
-          if (ret && ret.script) {
-            signedTx.tx.ins[i].s = ret.script
-            if (ret.inputFullySigned) signedTx.inputsSigned++
-            if (ret.signaturesAdded) signedTx.signaturesAdded += ret.signaturesAdded
-          }
-
-       }
-       return signedTx.tx.serialize().toString('hex')
-  }
-
-  _getDerivedWallet(derivedPath) {
-      if(this.seed.lengh > 64) {
-        const HDPrivateKey = bitcore.HDPrivateKey
-
-        const hdPrivateKey = new HDPrivateKey()
-        const retrieved = new HDPrivateKey(this.seed)
-        const derived = hdPrivateKey.derive(derivedPath) 
-        return derived 
+    for (let i = 0; i < unsignedTx.ins.length; i++) {
+      // init parameters
+      const txin = unsignedTx.ins[i]
+      const scriptPubKey = new bitcore.Script(txin.s)
+      const input = {
+        address: address,
+        scriptPubKey: scriptPubKey,
+        scriptType: scriptPubKey.classify(),
+        i: i,
       }
-      const PrivateKey = bitcore.PrivateKey
-      const imported = PrivateKey.fromWIF(this.seed)
-      return imported
+
+      // generating hash for signature
+      const txSigHash = unsignedTx.hashForSignature(scriptPubKey, i, bitcore.Transaction.SIGHASH_ALL)
+
+      // sign hash
+      const ret = fnToSign[input.scriptType].call(signedTx, wkMap, input, txSigHash)
+
+      // inject signed script in transaction object
+      if (ret && ret.script) {
+        signedTx.tx.ins[i].s = ret.script
+        if (ret.inputFullySigned) signedTx.inputsSigned++
+        if (ret.signaturesAdded) signedTx.signaturesAdded += ret.signaturesAdded
+      }
+    }
+    return signedTx.tx.serialize().toString('hex')
   }
 
+  _getDerivedWallet (derivedPath) {
+    if (this.seed.lengh > 64) {
+      const HDPrivateKey = bitcore.HDPrivateKey
+
+      const hdPrivateKey = new HDPrivateKey()
+      // const retrieved = new HDPrivateKey(this.seed)
+      const derived = hdPrivateKey.derive(derivedPath)
+      return derived
+    }
+    const PrivateKey = bitcore.PrivateKey
+    const imported = PrivateKey.fromWIF(this.seed)
+    return imported
+  }
 }

--- a/packages/core/services/signers/BitcoinTrezorDeviceMock.js
+++ b/packages/core/services/signers/BitcoinTrezorDeviceMock.js
@@ -4,13 +4,10 @@
  */
 
 import EventEmitter from 'events'
-import bip39 from 'bip39'
 import bitcoin from 'bitcoinjs-lib'
-import coinselect from 'coinselect'
-import axios from 'axios'
 
-export default class BitcoinMemoryDevice extends EventEmitter {
-  constructor ({seed, network}) {
+export default class BitcoinTrezorDeviceMock extends EventEmitter {
+  constructor ({ seed, network }) {
     super()
     this.seed = seed
     this.network = network
@@ -18,7 +15,7 @@ export default class BitcoinMemoryDevice extends EventEmitter {
   }
 
   privateKey (path) {
-    return this._getDerivedWallet(path).privateKey 
+    return this._getDerivedWallet(path).privateKey
   }
 
   // this method is a part of base interface
@@ -26,25 +23,25 @@ export default class BitcoinMemoryDevice extends EventEmitter {
     return this._getDerivedWallet(path).getAddress()
   }
 
-  signTransaction (rawTx, path) { // tx object
-    const txb = new bitcoin.TransactionBuilder.fromTransaction (
-      bitcoin.Transaction.fromHex (txhex), this.network)
+  signTransaction (rawTx, path) {
+    // tx object
+    const txb = new bitcoin.TransactionBuilder
+      .fromTransaction(bitcoin.Transaction.fromHex(txhex), this.network)
     for (let i = 0; i < txb.inputs.length; i++) {
-      txb.sign(i, _getDerivedWallet(path).keyPair)
+      txb.sign(i, this._getDerivedWallet(path).keyPair)
     }
-    const tx = txb.build ();
-    const txhex = tx.toHex ();
+    const tx = txb.build()
+    const txhex = tx.toHex()
     return txhex
   }
 
-  _getDerivedWallet(derivedPath) {
-    if(this.seed) {
+  _getDerivedWallet (derivedPath) {
+    if (this.seed) {
       const wallet = bitcoin.HDNode
         .fromSeedBuffer(Buffer.from(this.seed.substring(2), 'hex'), bitcoin.networks.testnet)
         .derivePath(derivedPath)
-      console.log(wallet)
+      // console.log(wallet)
       return wallet
     }
   }
-
 }

--- a/packages/core/services/signers/EthereumMemoryDevice.js
+++ b/packages/core/services/signers/EthereumMemoryDevice.js
@@ -14,9 +14,9 @@ export default class EthereumMemoryDevice extends EventEmitter {
     super()
     const accounts = new Accounts()
     const wallet = accounts.wallet.create()
-    console.log(privateKey)
+    // console.log(privateKey)
     const account = accounts.privateKeyToAccount(privateKey)
-    console.log(account)
+    // console.log(account)
     wallet.add(account)
     this.wallet = wallet[0]
     Object.freeze(this)
@@ -27,29 +27,31 @@ export default class EthereumMemoryDevice extends EventEmitter {
   }
 
   getPrivateKey (path) {
-    if(!path || path == DEFAULT_PATH) {
+    if (!path || path === DEFAULT_PATH) {
       return this.wallet.privateKey
     }
-      return EthereumMemoryDevice.getDerivedWallet(this.wallet.privateKey, path).address
+    return EthereumMemoryDevice.getDerivedWallet(this.wallet.privateKey, path).address
   }
 
   // this method is a part of base interface
   getAddress (path) {
-    if(!path || path == DEFAULT_PATH) {
+    if (!path || path === DEFAULT_PATH) {
       return this.address
     }
     return EthereumMemoryDevice.getDerivedWallet(this.wallet.privateKey, path).address
   }
 
-  async signTransaction (tx, path) { // tx object
-    if(!path || path == DEFAULT_PATH) {
+  async signTransaction (tx, path) {
+    // tx object
+    if (!path || path === DEFAULT_PATH) {
       return this.wallet.signTransaction(tx)
     }
     return EthereumMemoryDevice.getDerivedWallet(this.wallet.privateKey, path).signTransaction(tx)
   }
 
-  async signData (data, path) { // data object
-    if(!path || path == DEFAULT_PATH) {
+  async signData (data, path) {
+    // data object
+    if (!path || path === DEFAULT_PATH) {
       return this.wallet.sign(data)
     }
     return EthereumMemoryDevice.getDerivedWallet(this.wallet.privateKey, path).sign(data)
@@ -65,7 +67,7 @@ export default class EthereumMemoryDevice extends EventEmitter {
       wallet = wallet[0]
     }
     if (mnemonic) {
-      wallet = EthereumMemoryDevice.getDerivedWallet(mnemonic,null)
+      wallet = EthereumMemoryDevice.getDerivedWallet(mnemonic, null)
     }
     return { wallet: wallet.encrypt(password), path: DEFAULT_PATH, type: 'memory', address: wallet.address }
   }
@@ -79,20 +81,16 @@ export default class EthereumMemoryDevice extends EventEmitter {
   }
 
   static getDerivedWallet (seed, path) {
-    let _path
-    if(!path) {
-      _path = DEFAULT_PATH
-    } else {
-      _path = path
-    }
+    const walletPath = !path
+      ? DEFAULT_PATH
+      : path
     const accounts = new Accounts()
     const wallet = accounts.wallet.create()
     const hdWallet = hdKey.fromMasterSeed(seed)
-    const w = hdWallet.derivePath(_path).getWallet()
+    const w = hdWallet.derivePath(walletPath).getWallet()
     const account = accounts.privateKeyToAccount(`0x${w.getPrivateKey().toString('hex')}`)
-    wallet.add(account)  
-    console.log(wallet)
+    wallet.add(account)
+    // console.log(wallet)
     return wallet[0]
   }
-
 }

--- a/packages/core/services/signers/LedgerDevice.js
+++ b/packages/core/services/signers/LedgerDevice.js
@@ -11,9 +11,10 @@ const DEFAULT_PATH_FACTORY = (index) => `${DEFAULT_PATH}/${index}`
 
 const LOCK = 'LedgerDevice'
 
-const rejectOnTimeout = (timeout) => new Promise((resolve, reject) => {
-  setTimeout(() => reject(new Error('Timeout')), 2000)
-})
+const rejectOnTimeout = (timeout) =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => reject(new Error('Timeout')), timeout)
+  })
 
 export default class LedgerDevice extends EventEmitter {
   constructor () {
@@ -29,7 +30,7 @@ export default class LedgerDevice extends EventEmitter {
     return 'Ledger Device'
   }
 
-/*  async init () {
+  /*  async init () {
     return this._safeExec(
       async () => {
         try {
@@ -56,125 +57,116 @@ export default class LedgerDevice extends EventEmitter {
     )
   }*/
 
-  async getAddressInfoList (from: Number = 0, limit: Number = 5): String {
-    return this._safeExec(
-      async () => {
-          const addresses = []
-          for (let i = from; i < from + limit; i++) {
-            const path = DEFAULT_PATH_FACTORY(i)
-            const transport = await TransportU2F.create()
-            const app = new AppEth(transport)
-            const { address, publicKey } = await Promise.race([
-              this._getAddressInfo(app, path),
-              rejectOnTimeout(2000)
-            ])
-            addresses.push({
-              path,
-              address,
-              publicKey,
-	      type: this.name
-            })
-          }
-          return addresses
-        }
-    )
+  async getAddressInfoList (from: number = 0, limit: number = 5): String {
+    return this._safeExec(async () => {
+      const addresses = []
+      for (let i = from; i < from + limit; i++) {
+        const path = DEFAULT_PATH_FACTORY(i)
+        const transport = await TransportU2F.create()
+        const app = new AppEth(transport)
+        const { address, publicKey } = await Promise.race([this._getAddressInfo(app, path), rejectOnTimeout(2000)])
+        addresses.push({
+          path,
+          address,
+          publicKey,
+          type: this.name,
+        })
+      }
+      return addresses
+    })
   }
 
   async getAddress (path) {
-    return this._safeExec(
-      async () => {
-        if (this.isConnected) {
-            const transport = await TransportU2F.create()
-            const app = new AppEth(transport)
-            const { address } = await Promise.race([
-              this._getAddressInfo(app, path),
-              rejectOnTimeout(2000)
-            ])
-            return address
-        }
-        return
+    return this._safeExec(async () => {
+      if (this.isConnected) {
+        const transport = await TransportU2F.create()
+        const app = new AppEth(transport)
+        const { address } = await Promise.race([this._getAddressInfo(app, path), rejectOnTimeout(2000)])
+        return address
       }
-    )
+      return
+    })
   }
 
   async signTransaction (txData, path) {
-    return this._safeExec(
-      async () => {
-	console.log(txData)
-        const tx = new EthereumTx({
-          ...txData,
-          ...omitBy({
-            value: txData.value == null // nil check
-              ? null
-              : Web3Utils.toBN(txData.value),
-            fee: txData.fee == null // nil check
-              ? null
-              : Web3Utils.toBN(txData.fee),
-            gasLimit: txData.gasLimit == null // nil check
-              ? null
-              : Web3Utils.toBN(txData.gasLimit),
-            gasPrice: txData.gasPrice == null // nil check
-              ? null
-              : Web3Utils.toBN(txData.gasPrice),
-            nonce: txData.nonce == null // nil check
-              ? null
-              : Web3Utils.toBN(txData.nonce)
-          }, isNil)
-        })
+    return this._safeExec(async () => {
+      // console.log(txData)
+      const tx = new EthereumTx({
+        ...txData,
+        ...omitBy(
+          {
+            value:
+              txData.value == null // nil check
+                ? null
+                : Web3Utils.toBN(txData.value),
+            fee:
+              txData.fee == null // nil check
+                ? null
+                : Web3Utils.toBN(txData.fee),
+            gasLimit:
+              txData.gasLimit == null // nil check
+                ? null
+                : Web3Utils.toBN(txData.gasLimit),
+            gasPrice:
+              txData.gasPrice == null // nil check
+                ? null
+                : Web3Utils.toBN(txData.gasPrice),
+            nonce:
+              txData.nonce == null // nil check
+                ? null
+                : Web3Utils.toBN(txData.nonce),
+          },
+          isNil
+        ),
+      })
 
-        // // Set the EIP155 bits
-        tx.raw[6] = Buffer.from([txData.chainId]) // v
-        tx.raw[7] = Buffer.from([]) // r
-        tx.raw[8] = Buffer.from([]) // s
+      // // Set the EIP155 bits
+      tx.raw[6] = Buffer.from([txData.chainId]) // v
+      tx.raw[7] = Buffer.from([]) // r
+      tx.raw[8] = Buffer.from([]) // s
 
-        const transport = await TransportU2F.create()
-        const app = new AppEth(transport)
-        // Sign on ledger device
-        this.emit('prompt', { device: this.name })
-        const result = await app.signTransaction(
-          path,
-          tx.serialize().toString('hex')
-        )
+      const transport = await TransportU2F.create()
+      const app = new AppEth(transport)
+      // Sign on ledger device
+      this.emit('prompt', { device: this.name })
+      const result = await app.signTransaction(path, tx.serialize().toString('hex'))
 
-        // // Store signature in transaction
-        tx.v = Buffer.from(result.v, 'hex')
-        tx.r = Buffer.from(result.r, 'hex')
-        tx.s = Buffer.from(result.s, 'hex')
+      // // Store signature in transaction
+      tx.v = Buffer.from(result.v, 'hex')
+      tx.r = Buffer.from(result.r, 'hex')
+      tx.s = Buffer.from(result.s, 'hex')
 
-        // EIP155: v should be chain_id * 2 + {35, 36}
-        const signedChainId = Math.floor((tx.v[0] - 35) / 2)
-        const validChainId = txData.chainId
-        if (signedChainId !== validChainId) {
-          throw new Error(`[SignerLedgerModel] Invalid networkId signature returned. Expected: ${validChainId}, Got: ${signedChainId}`)
-        }
-
-        return {
-          rawTransaction: `0x${tx.serialize().toString('hex')}`
-        }
+      // EIP155: v should be chain_id * 2 + {35, 36}
+      const signedChainId = Math.floor((tx.v[0] - 35) / 2)
+      const validChainId = txData.chainId
+      if (signedChainId !== validChainId) {
+        throw new Error(`[SignerLedgerModel] Invalid networkId signature returned. Expected: ${validChainId}, Got: ${signedChainId}`)
       }
-    )
+
+      return {
+        rawTransaction: `0x${tx.serialize().toString('hex')}`,
+      }
+    })
   }
 
   async signData (data, path) {
-    return this._safeExec(
-      async () => {
-	console.log(data)
-        const transport = await TransportU2F.create()
-        const app = new AppEth(transport)
-        const result = await app.signPersonalMessage(path, Buffer.from(data).toString('hex'))
-	console.log(result)
-        const v = parseInt(result.v, 10) - 27
-        let vHex = v.toString(16)
-        if (vHex.length < 2) {
-          vHex = `0${v}`
-        }
-        console.log('vHex', vHex, v)
-        const signature = `0x${result.r}${result.s}${vHex}`
-        return {
-          signature: signature
-        }
+    return this._safeExec(async () => {
+      // console.log(data)
+      const transport = await TransportU2F.create()
+      const app = new AppEth(transport)
+      const result = await app.signPersonalMessage(path, Buffer.from(data).toString('hex'))
+      // console.log(result)
+      const v = parseInt(result.v, 10) - 27
+      let vHex = v.toString(16)
+      if (vHex.length < 2) {
+        vHex = `0${v}`
       }
-    )
+      // console.log('vHex', vHex, v)
+      const signature = `0x${result.r}${result.s}${vHex}`
+      return {
+        signature: signature,
+      }
+    })
   }
 
   async getAddressInfo (path: String): String {
@@ -189,14 +181,11 @@ export default class LedgerDevice extends EventEmitter {
     return {
       path,
       address,
-      publicKey
+      publicKey,
     }
   }
 
   async _safeExec (callable) {
-    return this.lock.acquire(
-      LOCK,
-      callable
-    )
+    return this.lock.acquire(LOCK, callable)
   }
 }

--- a/packages/core/services/signers/LedgerDeviceMock.js
+++ b/packages/core/services/signers/LedgerDeviceMock.js
@@ -1,10 +1,10 @@
 import EventEmitter from 'events'
 import hdkey from 'ethereumjs-wallet/hdkey'
-const BigNumber = require('bignumber.js')
 import Accounts from 'web3-eth-accounts'
+
 const DEFAULT_PATH = "m/44'/60'/0'/0"
 const DEFAULT_PATH_FACTORY = (index) => `${DEFAULT_PATH}/${index}`
-const MOCK_SEED = "advice shed boat scan game expire reveal rapid concert settle before vital" 
+const MOCK_SEED = 'advice shed boat scan game expire reveal rapid concert settle before vital'
 
 export default class LedgerDeviceMock extends EventEmitter {
   get name () {
@@ -15,29 +15,29 @@ export default class LedgerDeviceMock extends EventEmitter {
     return 'Ledger Device Mock'
   }
 
- async getAddressInfoList (from: Number = 0, limit: Number = 5): String {
+  async getAddressInfoList (from: number = 0, limit: number = 5): String {
     return Array.from({ length: limit }).map((element, index) => {
       return this.getAddressInfo(DEFAULT_PATH_FACTORY(from + index))
-      })
+    })
   }
 
   getAddressInfo (path) {
-    console.log(path)
+    // console.log(path)
     const hdKey = hdkey.fromMasterSeed(MOCK_SEED)
-     const wallet = hdKey.derivePath(path).getWallet()
-        return {
-          path: path,
-          address: `0x${wallet.getAddress().toString('hex')}`,
-          publicKey: wallet.getPublicKey().toString('hex'),
-          type: this.name,
-        }
+    const wallet = hdKey.derivePath(path).getWallet()
+    return {
+      path: path,
+      address: `0x${wallet.getAddress().toString('hex')}`,
+      publicKey: wallet.getPublicKey().toString('hex'),
+      type: this.name,
+    }
   }
 
   getAddress (path) {
     if (this.isConnected) {
       const hdKey = hdkey.fromMasterSeed(MOCK_SEED)
       const wallet = hdKey.derivePath(path).getWallet()
-        return `0x${wallet.getAddress().toString('hex')}`
+      return `0x${wallet.getAddress().toString('hex')}`
     }
     return
   }
@@ -47,7 +47,8 @@ export default class LedgerDeviceMock extends EventEmitter {
     const hdWallet = hdkey.fromMasterSeed(MOCK_SEED).derivePath(path)
     const wallet = hdWallet.getWallet()
     const account = await accounts.privateKeyToAccount(`0x${wallet.getPrivateKey().toString('hex')}`)
-    return await account.signTransaction(txData)
+    const signedTransaction = await account.signTransaction(txData)
+    return signedTransaction
   }
 
   async signData (data, path) {
@@ -55,6 +56,7 @@ export default class LedgerDeviceMock extends EventEmitter {
     const hdWallet = hdkey.fromMasterSeed(MOCK_SEED).derivePath(path)
     const w = hdWallet.getWallet()
     const account = await accounts.privateKeyToAccount(`0x${w.getPrivateKey().toString('hex')}`)
-    return await account.sign(data)
+    const signedData = await account.sign(data)
+    return signedData
   }
 }

--- a/packages/core/services/signers/NemMemoryDevice.js
+++ b/packages/core/services/signers/NemMemoryDevice.js
@@ -8,7 +8,7 @@ import nem from 'nem-sdk'
 import bitcore from 'bitcore-lib'
 
 export default class NemMemoryDevice extends EventEmitter {
-  constructor ({seed, network}) {
+  constructor ({ seed, network }) {
     super()
     this.seed = seed
     this.network = network
@@ -20,21 +20,20 @@ export default class NemMemoryDevice extends EventEmitter {
   }
 
   sign (data, path) {
-    return this._getDerivedWallet(path).sign(data)
+    return this._getDerWallet(path).sign(data)
   }
 
-  _getDerivedWallet(derivedPath) {
-      if(this.seed.lengh > 64) {
-        const HDPrivateKey = bitcore.HDPrivateKey
+  _getDerivedWallet (derivedPath) {
+    if (this.seed.lengh > 64) {
+      const HDPrivateKey = bitcore.HDPrivateKey
 
-        const hdPrivateKey = new HDPrivateKey()
-        const retrieved = new HDPrivateKey(this.seed)
-        const derived = hdPrivateKey.derive(derivedPath)
-        return nem.crypto.keyPair.create(derived)
-      }
-      const PrivateKey = bitcore.PrivateKey
-      const imported = PrivateKey.fromWIF(this.seed)
-      return nem.crypto.keyPair.create(imported)
+      const hdPrivateKey = new HDPrivateKey()
+      // const retrieved = new HDPrivateKey(this.seed)
+      const derived = hdPrivateKey.derive(derivedPath)
+      return nem.crypto.keyPair.create(derived)
+    }
+    const PrivateKey = bitcore.PrivateKey
+    const imported = PrivateKey.fromWIF(this.seed)
+    return nem.crypto.keyPair.create(imported)
   }
-
 }

--- a/packages/core/services/signers/NemTrezorDevice.js
+++ b/packages/core/services/signers/NemTrezorDevice.js
@@ -4,11 +4,10 @@
  */
 
 import EventEmitter from 'events'
-import nem from 'nem-sdk'
 import TrezorConnect from 'trezor-connect'
 
-export default class NemMemoryDevice extends EventEmitter {
-  constructor ({seed, network}) {
+export default class NemTrezorDevice extends EventEmitter {
+  constructor ({ seed, network }) {
     super()
     this.seed = seed
     this.network = network
@@ -19,17 +18,15 @@ export default class NemMemoryDevice extends EventEmitter {
     const result = await TrezorConnect.nemGetAddress({
       path: path,
       network: this.network,
-    }) 
-    return result.payload.address 
+    })
+    return result.payload.address
   }
 
   async sign (data, path) {
-    const result = await TrezorConnect.nemSignTransaction({       
+    const result = await TrezorConnect.nemSignTransaction({
       path: path,
       transaction: data,
     })
     return result.payload.signature
   }
-
-
 }

--- a/packages/core/services/signers/TrezorDeviceMock.js
+++ b/packages/core/services/signers/TrezorDeviceMock.js
@@ -1,10 +1,10 @@
 import EventEmitter from 'events'
 import hdkey from 'ethereumjs-wallet/hdkey'
-const BigNumber = require('bignumber.js')
 import Accounts from 'web3-eth-accounts'
+
 const DEFAULT_PATH = "m/44'/60'/0'/0"
 const DEFAULT_PATH_FACTORY = (index) => `${DEFAULT_PATH}/${index}`
-const MOCK_SEED = "advice shed boat scan game expire reveal rapid concert settle before vital" 
+const MOCK_SEED = 'advice shed boat scan game expire reveal rapid concert settle before vital'
 
 export default class TrezorDeviceMock extends EventEmitter {
   get name () {
@@ -15,29 +15,29 @@ export default class TrezorDeviceMock extends EventEmitter {
     return 'Trezor Device Mock'
   }
 
- async getAddressInfoList (from: Number = 0, limit: Number = 5): String {
+  async getAddressInfoList (from: number = 0, limit: number = 5): String {
     return Array.from({ length: limit }).map((element, index) => {
       return this.getAddressInfo(DEFAULT_PATH_FACTORY(from + index))
-      })
+    })
   }
 
   getAddressInfo (path) {
-    console.log(path)
+    // console.log(path)
     const hdKey = hdkey.fromMasterSeed(MOCK_SEED)
-     const wallet = hdKey.derivePath(path).getWallet()
-        return {
-          path: path,
-          address: `0x${wallet.getAddress().toString('hex')}`,
-          publicKey: wallet.getPublicKey().toString('hex'),
-          type: this.name,
-        }
+    const wallet = hdKey.derivePath(path).getWallet()
+    return {
+      path: path,
+      address: `0x${wallet.getAddress().toString('hex')}`,
+      publicKey: wallet.getPublicKey().toString('hex'),
+      type: this.name,
+    }
   }
 
   getAddress (path) {
     if (this.isConnected) {
       const hdKey = hdkey.fromMasterSeed(MOCK_SEED)
       const wallet = hdKey.derivePath(path).getWallet()
-        return `0x${wallet.getAddress().toString('hex')}`
+      return `0x${wallet.getAddress().toString('hex')}`
     }
     return
   }
@@ -47,7 +47,8 @@ export default class TrezorDeviceMock extends EventEmitter {
     const hdWallet = hdkey.fromMasterSeed(MOCK_SEED).derivePath(path)
     const wallet = hdWallet.getWallet()
     const account = await accounts.privateKeyToAccount(`0x${wallet.getPrivateKey().toString('hex')}`)
-    return await account.signTransaction(txData)
+    const signedTransaction  = await account.signTransaction(txData)
+    return signedTransaction
   }
 
   async signData (data, path) {
@@ -55,6 +56,7 @@ export default class TrezorDeviceMock extends EventEmitter {
     const hdWallet = hdkey.fromMasterSeed(MOCK_SEED).derivePath(path)
     const w = hdWallet.getWallet()
     const account = await accounts.privateKeyToAccount(`0x${w.getPrivateKey().toString('hex')}`)
-    return await account.sign(data)
+    const signedData = await account.sign(data)
+    return signedData
   }
 }


### PR DESCRIPTION
1) BitcoinLedgerDevice.js: OK
+ Commented console.log
+ Added return statement into signTransaction method
+ Rename AppBtc to AppBTC (wrong case)
+ File formatting and syntax
----------------------------------------------------------------------
2) BitcoinLedgerDeviceMock.js:
+ Removed unused imports
+ Fixed calling of _getDerivedWallet() method: added 'this'
+ File formatting and syntax
+ Renamed class from BitcoinMemoryDevice to BitcoinLedgerDeviceMock
- NOT FIXED: Variable 'txhex' should be referenced after its declaration at line 33.
There is no txhex in the TxEntryModel.js. Maybe we should use TxEntryModel.hash here?
```
  signTransaction (rawTx, path) {
    // tx object
    const txb = new bitcoin.TransactionBuilder.fromTransaction(bitcoin.Transaction.fromHex(txhex), this.network)
    for (let i = 0; i < txb.inputs.length; i++) {
      txb.sign(i, this._getDerivedWallet(path).keyPair)
    }
    const tx = txb.build()
    const txhex = tx.toHex()
    return txhex
  }
```
----------------------------------------------------------------------
3) BitcoinMemoryDevice.js
+ File formatting and syntax
+ Added Eslint rule /* eslint-disable no-underscore-dangle */ in appropriate place (using external lib)
+ Commented unused (yet) variables
----------------------------------------------------------------------
4) BitcoinTrezorDevice.js
+ Commented console.log and unused (yet) arguments
+ Added return statement into signTransaction method
+ + File formatting and syntax
----------------------------------------------------------------------
5) BitcoinTrezorDeviceMock.js
+ Renamed class from BitcoinMemoryDevice to BitcoinLedgerDeviceMock
+ Commented console.log
+ File formatting and syntax
- NOT FIXED: Variable 'txhex' should be referenced after its declaration at line 34.
There is no txhex in the TxEntryModel.js. Maybe we should use TxEntryModel.hash here?
```
  signTransaction (rawTx, path) {
    // tx object
    const txb = new bitcoin.TransactionBuilder
      .fromTransaction(bitcoin.Transaction.fromHex(txhex), this.network)
    for (let i = 0; i < txb.inputs.length; i++) {
      txb.sign(i, this._getDerivedWallet(path).keyPair)
    }
    const tx = txb.build()
    const txhex = tx.toHex()
    return txhex
  }
```
----------------------------------------------------------------------
6) EthereumMemoryDevice.js
+ Commented console.log
+ File formatting and syntax
+ Method getDerivedWallet has been rewritten a bit (functional is the same, variable with dangling "_" has been renamed)
----------------------------------------------------------------------
7) LedgerDevice.js
+ Commented console.log and unused (yet) arguments
+ File formatting and syntax
+ Method rejectOnTimeout (out of class) now using timepout as argument instead hardcoded 2000 (2 seconds)
+ Fixed flowtypes: Number -> number (Number is a constructor, should not be used as a type)
----------------------------------------------------------------------
8) LedgerDeviceMock.js
+ File formatting and syntax
+ Removed incorrect import of BigNumber (autoimport?)
+ Commented console.log
+ Fixed flowtypes: Number -> number (Number is a constructor, should not be used as a type)
+ Rewritten 'return await'. Reason: https://eslint.org/docs/rules/no-return-await
----------------------------------------------------------------------
9) NemMemoryDevice.js
+ Commented unused (yet) variables
+ File formatting and syntax
----------------------------------------------------------------------
10) NemTrezorDevice.js
+ Renamed class from NemMemoryDevice to NemTrezorDevice
+ File formatting and syntax
+ Removed unused imports
----------------------------------------------------------------------
11) TrezorDevice.js
+ File formatting and syntax
+ Removed incorrect import of BigNumber (autoimport?)
+ Fixed flowtypes: Number -> number (Number is a constructor, should not be used as a type)
+ Commented console.log
----------------------------------------------------------------------
12) TrezorDeviceMock.js
+ File formatting and syntax
+ Removed incorrect import of BigNumber (autoimport?)
+ Fixed flowtypes: Number -> number (Number is a constructor, should not be used as a type)
+ Commented console.log
+ Rewritten 'return await'. Reason: https://eslint.org/docs/rules/no-return-await
----------------------------------------------------------------------
13) DashMemoryDevice.js
+ File formatting and syntax
+ Replaced bitcore to dahcore (may be wrong, it was done like bitcore-lib analog)
+ Added Eslint rule /* eslint-disable no-underscore-dangle */ in appropriate place (using external lib)
- NOT FIXED: there is no dashcore-lib in package.json